### PR TITLE
Update gemspec to a new format

### DIFF
--- a/rspec-html-matchers.gemspec
+++ b/rspec-html-matchers.gemspec
@@ -20,7 +20,7 @@ DESC
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'rspec', '>= 2.0.0'
+  s.add_dependency 'rspec', '>= 2.11.0', '>= 2.0.0'
   s.add_dependency 'nokogiri', '>= 1.4.4'
 
   s.add_development_dependency 'simplecov'
@@ -28,5 +28,4 @@ DESC
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '>= 2.11.0' # in order to use new expect().to syntax
 end


### PR DESCRIPTION
Before building a gem (or installing as a dependency) fails with:

```
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    duplicate dependency on rspec (>= 2.11.0, development), (>= 2.0.0) use:
    add_runtime_dependency 'rspec', '>= 2.11.0', '>= 2.0.0'
```
